### PR TITLE
Fix the Homebrew Tap for Sigi

### DIFF
--- a/Formula/sigi.rb
+++ b/Formula/sigi.rb
@@ -2,32 +2,26 @@ class Sigi < Formula
   desc "Organizing tool for terminal lovers that hate organizing"
   license "GPL-2.0-only"
   homepage "https://github.com/hiljusti/sigi"
-  url "https://crates.io/api/v1/crates/sigi/3.1.1/download"
+  url "https://static.crates.io/crates/sigi/sigi-3.1.1.crate"
   sha256 "6d063ff4763e7f6925f0ca85563c2e7008e18983d66051361122d1f477bfd77d"
-  head "https://github.com/hiljusti/sigi.git"
+  head "https://github.com/hiljusti/sigi.git", branch: "core"
 
   depends_on "rust" => :build
-  
-  # TODO: Remove
-  def whereami msg
-    puts "================ BEGIN: $msg ================"
-    system "pwd"
-    system "ls", "-hal"
-    puts "================   END: $msg ================"
-  end
 
   def install
-    whereami 'before build' # TODO: Remove
+    # When using --head, Homebrew does a git clone and the install method
+    # is run from the context of that directory.
+    unless build.head?
+      # Otherwise, the create file is downloaded to a temporary directory, and
+      # then the install method is run from that directory, so we need to
+      # extract that crate file first. A crate file is just a tarball with a
+      # different file extension.
+      system "tar", "--strip-components", "1", "-xzvf", "sigi-#{version}.crate"
+    end
 
-    system "cargo", "build", "--release"
-
-    whereami 'after build' # TODO: Remove
-
+    system "cargo", "install", *std_cargo_args
     bin.install "target/release/sigi"
-
     man1.install "sigi.1"
-
-    whereami 'after install' # TODO: Remove
   end
 
   test do


### PR DESCRIPTION
- Corrected the download link for the Crate.
- A crate file is just a tarball. Homebrew downloads this file to a temporary directory and then runs the `install` method from the Formula with that temporary directory as the working directory. We thus need to extract the crate tarball before attempting to do `cargo install`.
- For `head` installs, we need to be explicit about the default branch name. Additionally, when you call `brew intall --head sigi`, Homebrew will do a `git clone` and then run the `install` method of the formula from the working directory of that git checkout, so we don't need to do the extract explicitly the way we do for regular installs.

Homebrew Taps are just git checkouts of the Tap repository, so I could iterate by editing the formula locally after adding the tap.

I based these changes off of the [oakc formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/oakc.rb) from the Homebrew core.

Output of a regular install on my personal M1 MacBook Air:
```
❯ brew install sigi
==> Downloading https://static.crates.io/crates/sigi/sigi-3.1.1.crate
######################################################################## 100.0%
==> Installing sigi from hiljusti/sigi
==> tar --strip-components 1 -xzvf sigi-3.1.1.crate
==> cargo install
🍺  /opt/homebrew/Cellar/sigi/3.1.1: 9 files, 1MB, built in 23 seconds
==> Running `brew cleanup sigi`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

~ took 25s
❯ sigi --version
sigi 3.1.1
```

Output of installing the `head` revision (after uninstalling the previous install with `brew uninstall sigi`:

```
❯ brew install sigi --head
==> Cloning https://github.com/hiljusti/sigi.git
Updating /Users/travishartwell/Library/Caches/Homebrew/sigi--git
==> Checking out branch core
Already on 'core'
Your branch is up to date with 'origin/core'.
HEAD is now at 54b299d Handle formats in interactive mode
==> Installing sigi from hiljusti/sigi
==> cargo install
🍺  /opt/homebrew/Cellar/sigi/HEAD-54b299d: 9 files, 1.3MB, built in 28 seconds
==> Running `brew cleanup sigi`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /Users/travishartwell/Library/Caches/Homebrew/sigi--3.1.1.crate... (24.4KB)
Removing: /Users/travishartwell/Library/Caches/Homebrew/sigi--3.1.1... (24.4KB)

~ took 32s
❯ sigi --version
sigi 3.1.1-NEXT
```

